### PR TITLE
doc: update README.md for osscontainertools rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Repository to build OCI images of Kaniko's fork
 
 * [chainguard-dev fork of kaniko](https://github.com/chainguard-dev/kaniko/)
-* [mzihlmann fork of kaniko](https://github.com/mzihlmann/kaniko)
+* [osscontainertools fork of kaniko](https://github.com/osscontainertools/kaniko) (formerly mzihlmann)
 
 Actions are taken from the original build process with few changes to adapt to ghcr and monkey patch version in `Makefile`.
 
@@ -12,6 +12,10 @@ Results are available at:
 * chainguard-dev/kaniko
   * Warmer: <https://github.com/kaniko-build/builder/pkgs/container/dist%2Fchainguard-dev-kaniko%2Fwarmer>
   * Executor: <https://github.com/kaniko-build/builder/pkgs/container/dist%2Fchainguard-dev-kaniko%2Fexecutor>
-* mzihlmann/kaniko
+* osscontainertools/kaniko (formerly mzihlmann)
+  * Warmer: <https://github.com/kaniko-build/builder/pkgs/container/dist%2Fosscontainertools-kaniko%2Fwarmer>
+  * Executor: <https://github.com/kaniko-build/builder/pkgs/container/dist%2Fosscontainertools-kaniko%2Fexecutor>
+
+* mzihlmann/kaniko (retained for backward compatibility but no longer build)
   * Warmer: <https://github.com/kaniko-build/builder/pkgs/container/dist%2Fmzihlmann-kaniko%2Fwarmer>
-  * Executor: <https://github.com/kaniko-build/builder/pkgs/container/dist%2Fchainguard-dev-kaniko%2Fexecutor>
+  * Executor: <https://github.com/kaniko-build/builder/pkgs/container/dist%2Fmzihlmann-kaniko%2Fexecutor>


### PR DESCRIPTION
* fix: typo in url

Signed-off-by: Damien Degois <damien@degois.info>
